### PR TITLE
Aggiuti file da ignorare a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,18 @@ dist/
 .coverage
 .pytest_cache/
 htmlcov/
+
+# Node modules (dipendenze installate)
+node_modules/
+
+# Log e debug
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Sistema operativo
+.DS_Store
+Thumbs.db
+
+# Dati temporanei
+*.log


### PR DESCRIPTION
Sono stati aggiunti nuovi file da ignorare, soprattutto node_modules. fondamentale.